### PR TITLE
Getter for refreshed tokens, cleanup

### DIFF
--- a/lib/hubspot/hubspot.js
+++ b/lib/hubspot/hubspot.js
@@ -232,7 +232,7 @@ hubspotAPI.prototype.delete = function (path, availableParams, givenParams, call
 };
 
 /**
- * access to access/refresh tokens for peristence
+ * access to access/refresh tokens for persistence
  * @return {object} {access_token, refresh_token}
  */
 hubspotAPI.prototype.getTokens = function(){

--- a/lib/hubspot/hubspot.js
+++ b/lib/hubspot/hubspot.js
@@ -149,7 +149,7 @@ hubspotAPI.prototype.execute = function (verbParams, path, availableParams, give
   requestOptions.uri = uri;
 
   if (self.DEBUG) {
-    console.log("req", requestOptions);
+    console.log("requestOptions", requestOptions);
   }
 
   request(requestOptions, function (error, res, body) {
@@ -185,6 +185,7 @@ hubspotAPI.prototype.execute = function (verbParams, path, availableParams, give
 };
 
 function processResponseBody(statusCode, body, callback) {
+
   if (helpers.isAnError(statusCode)) {
     return callback(helpers.createHubspotError(body, statusCode));
   }
@@ -230,6 +231,17 @@ hubspotAPI.prototype.delete = function (path, availableParams, givenParams, call
   this.execute("DELETE", path, availableParams, givenParams, callback);
 };
 
+/**
+ * access to access/refresh tokens for peristence
+ * @return {object} {access_token, refresh_token}
+ */
+hubspotAPI.prototype.getTokens = function(){
+  return {
+    access_token: this.access_token,
+    refresh_token: this.refresh_token
+  };
+};
+
 /*****************************************************************************/
 /************************* TOKEN Methods **********************************/
 /*****************************************************************************/
@@ -272,7 +284,7 @@ hubspotAPI.prototype.refreshAccessToken = function(refresh_token, callback) {
   this.post(path, availableParams, params, callback);
 };
 
-hubspotAPI.prototype.resetAccessToken = function(access_token, refresh_token, callback) {
+hubspotAPI.prototype.resetAccessToken = function(refresh_token, callback) {
   var self = this;
   self.refreshAccessToken(refresh_token, function (err, tokenInfo) {
     if (err) {
@@ -349,7 +361,7 @@ hubspotAPI.prototype.createOrUpdateTimelineEvent = function(eventTypeId, email, 
     if (err) {
       // if unauthorized error
       if(err.statusCode === 401) {
-        self.resetAccessToken(self.access_token, self.refresh_token, function (err) {
+        self.resetAccessToken(self.refresh_token, function (err, tokenInfo) {
           if (err) {
             return callback(err, result);
           }

--- a/package.json
+++ b/package.json
@@ -17,11 +17,12 @@
     "test": "mocha ./test"
   },
   "dependencies": {
+    "chai": "^3.5.0",
+    "lodash": "3.6.0",
+    "mocha": "^3.2.0",
+    "moment": "^2.18.1",
     "querystring": "^0.2.0",
     "request": "2.x.x",
-    "lodash": "3.6.0",
-    "chai": "^3.5.0",
-    "mocha": "^3.2.0",
     "sinon": "^1.17.6"
   }
 }


### PR DESCRIPTION
- access new tokens upon refresh so we can persist in parent code
- don't need access_token for resetAccessToken call
- naming 